### PR TITLE
Feat: Edit prettier config

### DIFF
--- a/packages/prettier/.prettierrc.json
+++ b/packages/prettier/.prettierrc.json
@@ -4,5 +4,5 @@
   "singleQuote": true,
   "tabWidth": 2,
   "jsxBracketSameLine": true,
-  "trailingComma": "none"
+  "trailingComma": "es5"
 }

--- a/packages/prettier/.prettierrc.json
+++ b/packages/prettier/.prettierrc.json
@@ -4,5 +4,5 @@
   "singleQuote": true,
   "tabWidth": 2,
   "jsxBracketSameLine": true,
-  "trailingComma": "es5"
+  "trailingComma": "all"
 }

--- a/packages/prettier/package.json
+++ b/packages/prettier/package.json
@@ -11,11 +11,11 @@
     "url": "ssh://git@github.com:unlikelystudio/bases.git"
   },
   "files": [
-    "prettier.json"
+    ".prettierrc.json"
   ],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "prettier": "./prettier.json",
+  "prettier": "./.prettierrc.json",
   "gitHead": "ae4660056efed665405739a1ce70dc2acc75e551"
 }

--- a/packages/prettier/readme.md
+++ b/packages/prettier/readme.md
@@ -14,6 +14,6 @@ In your package.json
 
 ```json
 {
-  "prettier": "@unlikelystudio/bases-prettier"
+  "prettier": "@unlikelystudio/bases-prettier/.prettierrc.json"
 }
 ```


### PR DESCRIPTION
- Edit incorrect example on the readme
- Switch trailingComma key to "all" instead of none: https://prettier.io/docs/en/options.html#trailing-commas
- Edit prettier config file name to match the best practices in the documentation 