### PR TITLE
Chore: Update target from esnext to es5

### DIFF
--- a/packages/typescript/dom.json
+++ b/packages/typescript/dom.json
@@ -4,7 +4,7 @@
     "module": "esnext",
     "lib": ["dom", "dom.iterable", "esnext"],
     "noEmit": true,
-    "target": "esnext",
+    "target": "es5",
     "paths": {
       "@/*": ["src/*"]
     }


### PR DESCRIPTION
We shouldn't transpile client ts code to esnext because very few browsers support all features of es2020 right now. es5 seems to be a the right fit between ts default (es3) and today's browser support. For example with esnext as a target, optionnal chaining is not transpiled.