### PR TITLE
Chore: eslint config updates

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -11,5 +11,5 @@
     }
   },
   "npmClient": "yarn",
-  "version": "1.7.0"
+  "version": "1.8.0"
 }

--- a/packages/eslint/index.js
+++ b/packages/eslint/index.js
@@ -24,5 +24,7 @@ module.exports = {
   ],
   rules: {
     '@typescript-eslint/explicit-module-boundary-types': 'off',
+    'react-hooks/exhaustive-deps': 'off',
+    'react/react-in-jsx-scope': 'off',
   },
 }

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlikelystudio/eslint-config",
-  "version": "1.6.1",
+  "version": "1.8.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/eslint/yarn.lock
+++ b/packages/eslint/yarn.lock
@@ -67,11 +67,6 @@
     "@typescript-eslint/types" "4.27.0"
     eslint-visitor-keys "^2.0.0"
 
-"@unlikelystudio/bases-prettier@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@unlikelystudio/bases-prettier/-/bases-prettier-1.3.0.tgz#733c7e8a2693f5aca775fa14d0fb398193db6f34"
-  integrity sha512-91Qp2PESCRmEhp3njcDVzZLrfW9GVWM3n8aCZ8iU7i5xpYOFfEQhIhrcM4QiD3Vj6gn7+KVDDqgWsRfFdyk9ew==
-
 array-union@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"

--- a/packages/plop/package.json
+++ b/packages/plop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlikelystudio/bases-plop",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "engines": {
     "node": ">=12.0.0"
   },

--- a/packages/plop/yarn.lock
+++ b/packages/plop/yarn.lock
@@ -85,11 +85,6 @@
   dependencies:
     "@types/node" "*"
 
-"@unlikelystudio/bases-prettier@^1.5.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@unlikelystudio/bases-prettier/-/bases-prettier-1.3.0.tgz#733c7e8a2693f5aca775fa14d0fb398193db6f34"
-  integrity sha512-91Qp2PESCRmEhp3njcDVzZLrfW9GVWM3n8aCZ8iU7i5xpYOFfEQhIhrcM4QiD3Vj6gn7+KVDDqgWsRfFdyk9ew==
-
 aggregate-error@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.1.0.tgz#92670ff50f5359bdb7a3e0d40d0ec30c5737687a"


### PR DESCRIPTION
- [x] add two excluding rules in eslint config
   - [x] **react-hooks/exhaustive-deps** prevents warn issue on hooks dependencies
   - [x] **react/react-in-jsx-scope** prevents warn issue on files not importing React (unrequired since next@12)